### PR TITLE
Fix up package runtime dependencies

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,7 +12,6 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,3 +1,5 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @astrofrog-conda-forge @drdavella @mwcraig
+* @anthchirp @astrofrog-conda-forge @mwcraig @pllim

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -29,13 +29,25 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --suppress-variables \
-    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
-if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
+    fi
+    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    # Drop into an interactive shell
+    /bin/bash
+else
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+        upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    fi
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About pytest-doctestplus
 ========================
 
-Home: https://pypi.org/project/pytest-doctestplus
+Home: https://github.com/astropy/pytest-doctestplus
 
 Package license: BSD-3-Clause
 
@@ -11,7 +11,7 @@ Summary: Pytest plugin with advanced doctest features.
 
 Development: https://github.com/astropy/pytest-doctestplus
 
-Documentation: https://astropy.org
+Documentation: https://pypi.org/project/pytest-doctestplus/
 
 This package contains a plugin for the pytest framework that provides
 advanced doctest support and enables the testing of reStructuredText files.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 About pytest-doctestplus
 ========================
 
-Home: https://github.com/astropy/pytest-doctestplus
+Home: https://pypi.org/project/pytest-doctestplus
 
 Package license: BSD-3-Clause
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pytest-doctestplus-feedstock/blob/master/LICENSE.txt)
 
-Summary: Pytest plugin with advanced doctest features
+Summary: Pytest plugin with advanced doctest features.
+
+Development: https://github.com/astropy/pytest-doctestplus
+
+Documentation: https://astropy.org
 
 This package contains a plugin for the pytest framework that provides
 advanced doctest support and enables the testing of reStructuredText files.
@@ -118,7 +122,8 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@anthchirp](https://github.com/anthchirp/)
 * [@astrofrog-conda-forge](https://github.com/astrofrog-conda-forge/)
-* [@drdavella](https://github.com/drdavella/)
 * [@mwcraig](https://github.com/mwcraig/)
+* [@pllim](https://github.com/pllim/)
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.rst
-  doc_url: https://github.com/astropy/pytest-doctestplus
+  doc_url: https://pypi.org/project/pytest-doctestplus/
   dev_url: https://github.com/astropy/pytest-doctestplus
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,49 +1,52 @@
 {% set name = "pytest-doctestplus" %}
 {% set version = "0.8.0" %}
-{% set git_url = "https://github.com/astropy/pytest-doctestplus" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pytest-doctestplus-{{ version }}.tar.gz
   sha256: fb083925a17ce636f33997c275f61123e63372c1db11fefac1e991ed25a4ca37
 
 build:
+  number: 1
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
-  build:
+  host:
+    - pip
     - python >=3.6
+  run:
     - pip
     - pytest >=4.0
-  run:
     - python >=3.6
-    - pytest >=4.0
-    - numpy >=1.10
+    - setuptools >=30.3
 
 test:
   imports:
     - pytest_doctestplus
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
-  home: {{ git_url }}
-  license_family: BSD
-  license: BSD-3-Clause
-  license_file: LICENSE.rst
-  summary: Pytest plugin with advanced doctest features
+  home: https://pypi.org/project/pytest-doctestplus
+  summary: Pytest plugin with advanced doctest features.
   description: |
     This package contains a plugin for the pytest framework that provides
     advanced doctest support and enables the testing of reStructuredText files.
-  doc_url: {{ git_url }}
-  dev_url: {{ git_url }}
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.rst
+  doc_url: https://astropy.org
+  dev_url: https://github.com/astropy/pytest-doctestplus
 
 extra:
   recipe-maintainers:
+    - anthchirp
     - astrofrog-conda-forge
     - pllim
     - mwcraig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
     - pip
 
 about:
-  home: https://pypi.org/project/pytest-doctestplus
+  home: https://github.com/astropy/pytest-doctestplus
   summary: Pytest plugin with advanced doctest features.
   description: |
     This package contains a plugin for the pytest framework that provides
@@ -41,7 +41,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.rst
-  doc_url: https://astropy.org
+  doc_url: https://github.com/astropy/pytest-doctestplus
   dev_url: https://github.com/astropy/pytest-doctestplus
 
 extra:


### PR DESCRIPTION
* regenerate the recipe using grayskull
* add setuptools runtime dependency (cf. https://github.com/astropy/pytest-doctestplus/issues/93#issuecomment-723443925 and https://github.com/astropy/pytest-doctestplus/pull/132) 
* remove numpy runtime dependency ([dropped in 0.5.0](https://github.com/astropy/pytest-doctestplus/blob/master/CHANGES.rst#050-2019-11-15))
* add myself as maintainer

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
